### PR TITLE
feat: babel import assertions plugin

### DIFF
--- a/esm.js
+++ b/esm.js
@@ -13,7 +13,11 @@ module.exports = {
       modules: true,
     },
     babelOptions: {
-      plugins: ['@babel/plugin-proposal-class-properties', '@babel/plugin-proposal-private-methods'],
+      plugins: [
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-proposal-private-methods',
+        '@babel/plugin-syntax-import-assertions',
+      ],
     },
   },
 };

--- a/esm.js
+++ b/esm.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   rules: {
-    'import/extensions': 0,
+    'import/extensions': ['error', 'always'],
   },
   extends: ['@wfcd'],
   parser: '@babel/eslint-parser',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/eslint-parser": "^7.19.1",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
     "@babel/plugin-proposal-private-methods": "^7.18.6",
+    "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "@babel/preset-env": "^7.19.1",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Add compatibility to ESM import assertions that node uses

---

### Reproduction steps
1. Add the `@babel/plugin-syntax-import-assertions` as dependency
2. Add it to the `esm.js` babel plugins section
3. Change `import/extensions` in `esm.js` rules to always

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[Yes]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Feature]**
