### PR TITLE
fix: import/no-extraneous-dependencies globs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,7 +50,7 @@ module.exports = {
     'import/no-unresolved': 0,
     'import/no-extraneous-dependencies': [
       'error',
-      { devDependencies: ['**/*.test.c?m?js', '**/*.spec.c?m?js', 'build/**/*.c?m?js'] },
+      { devDependencies: ['**/*.test.{js,cjs,mjs}', '**/*.spec.{js,cjs,mjs}', 'build/**/*.{js,cjs,mjs}'] },
     ],
     'no-null/no-null': 2,
     quotes: [


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
Glob patterns not working as expected. The character for optional value `?` does not work 

---

### Reproduction steps

---

### Evidence/screenshot/link to line

### Considerations
- Does this contain a new dependency? **[No]**
- Does this introduce opinionated data formatting or manual data entry? **[Yes]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[Yes]**
- Is is a bug fix, feature request, or enhancement? **[Bug Fix]**
