### PR TITLE
feat: strict jsdoc config available

### DIFF
--- a/configs/.eslintrc.js
+++ b/configs/.eslintrc.js
@@ -23,15 +23,21 @@ module.exports = {
     ],
     strict: ['error', 'safe'],
     'linebreak-style': ['error', 'unix'],
-    'no-await-in-loop': 'off',
     'func-names': 0,
     'arrow-parens': ['error', 'always'],
     'global-require': 0,
+    'no-await-in-loop': 'off',
     'no-param-reassign': 'off',
     'no-continue': 'off',
-    'lines-between-class-members': 'off',
+    'no-underscore-dangle': [
+      'error',
+      {
+        allow: ['__basedir', '__dirname'],
+      },
+    ],
     'no-fallthrough': 'off',
     'no-case-declarations': 'off',
+    'lines-between-class-members': 'off',
     'default-case': 'off',
     'max-classes-per-file': 'off',
     'consistent-return': 'off',
@@ -52,6 +58,13 @@ module.exports = {
       'error',
       { devDependencies: ['**/*.test.{js,cjs,mjs}', '**/*.spec.{js,cjs,mjs}', 'build/**/*.{js,cjs,mjs}'] },
     ],
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'index'],
+        'newlines-between': 'always',
+      },
+    ],
     'no-null/no-null': 2,
     quotes: [
       2,
@@ -66,12 +79,6 @@ module.exports = {
       {},
       {
         usePrettierrc: true,
-      },
-    ],
-    'no-underscore-dangle': [
-      'error',
-      {
-        allow: ['__basedir', '__dirname'],
       },
     ],
   },

--- a/configs/strict-esm-jsdoc.js
+++ b/configs/strict-esm-jsdoc.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'valid-jsdoc': ['off'],
+  },
+  extends: ['@wfcd/eslint-config/esm', 'plugin:jsdoc/recommended-typescript-flavor-error'],
+  parser: '@babel/eslint-parser',
+  parserOptions: {
+    sourceType: 'module',
+    ecmaVersion: 6,
+    ecmaFeatures: {
+      modules: true,
+    },
+    babelOptions: {
+      plugins: [
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-proposal-private-methods',
+        '@babel/plugin-syntax-import-assertions',
+      ],
+    },
+  },
+};

--- a/configs/strict-jsdoc.js
+++ b/configs/strict-jsdoc.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'valid-jsdoc': ['off'],
+  },
+  extends: ['@wfcd', 'plugin:jsdoc/recommended-typescript-flavor-error'],
+  parser: '@babel/eslint-parser',
+  parserOptions: {
+    ecmaVersion: 6,
+    babelOptions: {
+      plugins: [
+        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-proposal-private-methods',
+        '@babel/plugin-syntax-import-assertions',
+      ],
+    },
+  },
+};

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "./esm": "./configs/esm.js",
     "./prettier": "./configs/prettier.config.js",
     "./typescript": "./configs/typescript.js",
-    "./strict-jsdoc": "./configs/strict-jsdoc.js"
+    "./strict-jsdoc": "./configs/strict-jsdoc.js",
+    "./strict-esm-jsdoc": "./configs/strict-esm-jsdoc.js"
   },
   "peerDependencies": {
     "@babel/core": "^7.19.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     ".": "./configs/.eslintrc.js",
     "./esm": "./configs/esm.js",
     "./prettier": "./configs/prettier.config.js",
-    "./typescript": "./configs/typescript.js"
+    "./typescript": "./configs/typescript.js",
+    "./strict-jsdoc": "./configs/strict-jsdoc.js"
   },
   "peerDependencies": {
     "@babel/core": "^7.19.1",
@@ -43,6 +44,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-airbnb-typescript": "17.0.0",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jsdoc": "^48.0.6",
     "eslint-plugin-no-null": "^1.0.2",
     "eslint-plugin-prettier": "^4.2.1",
     "prettier": "^2.7.1"


### PR DESCRIPTION
### What did you fix? <!-- provide a description or issue closes statement -->
thing to do strict jsdoc

---

### Reproduction steps
<!--
1. I did the thing
1. Then I clicked the button
1. Then I deleted the word
1. Then I found the error!
-->

---

### Evidence/screenshot/link to line

<!-- You can see my fix [on this line](#line-number-1235234) for where the new data exists -->

### Considerations
- Does this contain a new dependency? **[Yes]**
- Does this introduce opinionated data formatting or manual data entry? **[No]**
- Does this pr include updated data files in a separate commit that can be reverted for a clean code-only pr? **[No]**
- Have I run the linter? **[No]**
- Is is a bug fix, feature request, or enhancement? **[Feature]**
